### PR TITLE
Update YVR to indicate it lies in Richmond

### DIFF
--- a/data/yvr.json
+++ b/data/yvr.json
@@ -2,12 +2,12 @@
     "id": "yvr",
     "code": "yvr",
     "name": "Vancouver International Airport",
-    "city": "Vancouver",
-    "city2": "Richmond",
+    "city": "Richmond",
+    "city2": "Vancouver",
     "state": "British Columbia",
     "stateShort": "BC",
     "country": "Canada",
-    "description": "With a few exceptions, airport codes starting with ‘*Y*’ designate Canadian airports. The next two letters come from its home in *V*ancouve*r*.",
+    "description": "With a few exceptions, airport codes starting with ‘*Y*’ designate Canadian airports. The next two letters come from the major port city it serves, *V*ancouve*r*.",
     "imageCredit": "Rick Schwartz",
     "imageCreditLink": "https://www.flickr.com/photos/justenoughfocus/"
 }


### PR DESCRIPTION
Vancouver International Airport actually exists in Richmond, BC (though it is nominally considered to serve Vancouver, just to its north). Thus, I have inverted `city` and `city2` and adjusted the description slightly.