### PR TITLE
this removes the need to have gulp installed globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ If you'd like to add an airport or fix an error, please:
 
 ```
 npm install
-gulp
+
+npm run dev
 ```
 
 ## Adding/Editing Airport Content

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Airport Codez!",
   "main": "index.js",
   "scripts": {
+    "dev": "gulp",
+    "build": "gulp build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
You dont need a global copy of gulp installed to run in through npm. 

to test, `npm install` then `npm run dev`