### PR TITLE
Create REC

### DIFF
--- a/REC
+++ b/REC
@@ -1,0 +1,2 @@
+lease add the code REC for Recife Guararapes Gilberto Freire International Airport, in Brazil. The code derives from the city 
+initials RECife


### PR DESCRIPTION
Please add the code REC for Recife Guararapes Gilberto Freire International Airport, in Brazil. The code derives from the city 
initials RECife