### PR TITLE
Fixing incorrect attribution

### DIFF
--- a/data/sxl.json
+++ b/data/sxl.json
@@ -5,6 +5,6 @@
     "city2": "Strandhill",
     "country": "Ireland",
     "description": "Sligo Airport is located in the small coastal town of Strandhill and gets its code and name from *Sl*igo, the nearby large town it serves. A filler letter *X* completes its code.",
-    "imageCredit": "Wolf32at",
-    "imageCreditLink": "http://commons.wikimedia.org/wiki/File:Shannon-airport-building-2008.jpg"
+    "imageCredit": "Zxcode",
+    "imageCreditLink": "https://commons.wikimedia.org/wiki/File:Sligo-control-tower.jpg"
 }


### PR DESCRIPTION
I accidentally forgot to attribute the author of the photo for SXL. This commit corrects that.