### PR TITLE
Fix Singapore Changi Airport name

### DIFF
--- a/data/sin.json
+++ b/data/sin.json
@@ -1,6 +1,6 @@
 {
     "id": "sin",
-    "name": "Lapangan Terbang Changi Singapura",
+    "name": "Singapore Changi Airport",
     "city": "Singapore",
     "city2": "Changi",
     "country": "Singapore",


### PR DESCRIPTION
Changi Airport's official name [is in English](https://www.flightradar24.com/data/airports/sin), not Malay.