### PR TITLE
Rename Phoenix-Mesa Gateway Airport to Mesa Gateway Airport

### DIFF
--- a/data/aza.json
+++ b/data/aza.json
@@ -1,12 +1,11 @@
 {
     "id": "aza",
-    "name": "Phoenix-Mesa Gateway Airport",
-    "city": "Phoenix",
-    "city2": "Mesa",
+    "name": "Mesa Gateway Airport",
+    "city": "Mesa",
     "state": "Arizona",
     "stateShort": "AZ",
     "country": "USA",
-    "description": "Formerly named after 1st Lt. Charles Williams of the U.S. Army Air Corps, Phoenix-Mesa Gateway is the lucky airport whose airport code honors its home state of *A*ri*z*on*a*.",
+    "description": "Formerly named after 1st Lt. Charles Williams of the U.S. Army Air Corps, Mesa Gateway is the lucky airport whose airport code honors its home state of *A*ri*z*on*a*.",
     "imageCredit": "David Crummey",
     "imageCreditLink": "https://www.flickr.com/photos/dcrummey/"
 }


### PR DESCRIPTION
The airport was renamed in late 2024 after the city of Phoenix withdrew from the airport's board: https://www.mesanow.org/news/public/article/3422

...Unless it would be better to say "Formerly Phoenix-Mesa Gateway Airport," but there's already a "formerly" for this airport, so I don't know what the best way would be