### PR TITLE
Add MTN — Buddha Air Everest mountain flight

### DIFF
--- a/data/mtn.json
+++ b/data/mtn.json
@@ -1,0 +1,8 @@
+{
+    "id": "mtn",
+    "name": "Buddha Air Mountain Flight",
+    "city": "Kathmandu",
+    "country": "Nepal",
+    "city2": "Everest",
+    "description": "Not every code leads to a destination. Buddha Air's early-morning sightseeing flight lifts off from Kathmandu, drifts along the Himalaya for a face-to-face with Everest, and lands an hour later on the very same runway. The airline gives the loop a code all its own, for the *M*oun*t*ai*n* it was named after."
+}


### PR DESCRIPTION
Adds a page for **MTN** — but a slightly unusual one. 🏔️

On a recent Buddha Air boarding pass out of Kathmandu, my flight read **KTM → MTN**. There's no airport called MTN in Nepal: it's the code the airline uses for its early-morning **mountain flight**, the scenic Himalayan sightseeing loop that flies you up to Everest and lands you back on the very same KTM runway an hour later. A boarding pass to nowhere and everywhere at once.

I know the site is a catalogue of *real* airport codes (and that IATA MTN officially belongs to Martin State Airport in Maryland), so I've framed the entry clearly as the airline's mountain-flight code rather than a fake airport — in case you'd enjoy the oddity. Totally understand if it's not a fit, and I'm happy to instead:

- rewrite it as the proper **Martin State Airport (MTN)** entry, or
- close this if it's out of scope.

The code maps nicely either way: *M*oun*t*ai*n* / *M*ar*t*i*n*.

No image included yet — glad to add a Creative Commons photo of the flight/Everest if you'd like the entry.
